### PR TITLE
config::project_repos optional

### DIFF
--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -280,7 +280,7 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
         // Environment setup
         steps.stage("Environment Setup") {
             // Checkout repositories to workspace with defined repository name
-            projectConfig.config.project_repos.each { repo_name, repo_confs ->
+            projectConfig.config.project_repos.?each { repo_name, repo_confs ->
                 steps.checkout scm: [$class: 'GitSCM', userRemoteConfigs: [[url: repo_confs.repo]],
                                branches: [[name: repo_confs.branch]],
                                extensions: [[$class: 'CleanCheckout', deleteUntrackedNestedRepositories: true],

--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -280,7 +280,7 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
         // Environment setup
         steps.stage("Environment Setup") {
             // Checkout repositories to workspace with defined repository name
-            projectConfig.config.project_repos.?each { repo_name, repo_confs ->
+            projectConfig.config.project_repos?.each { repo_name, repo_confs ->
                 steps.checkout scm: [$class: 'GitSCM', userRemoteConfigs: [[url: repo_confs.repo]],
                                branches: [[name: repo_confs.branch]],
                                extensions: [[$class: 'CleanCheckout', deleteUntrackedNestedRepositories: true],

--- a/src/eu/indigo/compose/parser/ConfigParser.groovy
+++ b/src/eu/indigo/compose/parser/ConfigParser.groovy
@@ -150,7 +150,7 @@ class ConfigParser extends JenkinsDefinitions implements Serializable {
         def configBase = merge(getDefaultValue('config'), config)
         def configRepos = [
             project_repos: configBase['project_repos']
-                .?collectEntries { id, repo ->
+                ?.collectEntries { id, repo ->
                     [id, merge(getDefaultValue('config_repo'), repo)]
                 }
         ]

--- a/src/eu/indigo/compose/parser/ConfigParser.groovy
+++ b/src/eu/indigo/compose/parser/ConfigParser.groovy
@@ -150,7 +150,7 @@ class ConfigParser extends JenkinsDefinitions implements Serializable {
         def configBase = merge(getDefaultValue('config'), config)
         def configRepos = [
             project_repos: configBase['project_repos']
-                .collectEntries { id, repo ->
+                .?collectEntries { id, repo ->
                     [id, merge(getDefaultValue('config_repo'), repo)]
                 }
         ]


### PR DESCRIPTION
For the use cases that only need the triggered branch is not required to defined any config::project_repos.
This PR brings that option into current release.