### PR TITLE
Add private repository support

### DIFF
--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -281,7 +281,7 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
         steps.stage("Environment Setup") {
             // Checkout repositories to workspace with defined repository name
             projectConfig.config.project_repos.each { repo_name, repo_confs ->
-                steps.checkout scm: [$class: 'GitSCM', userRemoteConfigs: [[url: repo_confs.repo]],
+                steps.checkout scm: [$class: 'GitSCM', userRemoteConfigs: [[url: repo_confs.repo, credentialsId: repo_confs.credentials_id]],
                                branches: [[name: repo_confs.branch]],
                                extensions: [[$class: 'CleanCheckout', deleteUntrackedNestedRepositories: true],
                                             [$class: 'GitLFSPull'],

--- a/vars/pipelineConfig.groovy
+++ b/vars/pipelineConfig.groovy
@@ -11,9 +11,10 @@ def call(
     String configFile='./.sqa/config.yml',
     String baseRepository=null,
     String baseBranch=null,
+    String credentialsId=null,
     String validatorDockerImage='eoscsynergy/jpl-validator:1.1.0') {
 
-    checkoutRepository(baseRepository, baseBranch)
+    checkoutRepository(baseRepository, baseBranch, credentialsId)
     def yaml = readYaml file: configFile
     def buildNumber = Integer.parseInt(env.BUILD_ID)
     ProjectConfiguration projectConfig = null
@@ -43,18 +44,18 @@ def call(
 }
 
 def validate(String configFile, String validatorDockerImage) {
-    def cmd = 'docker pull ' + "$validatorDockerImage &&" +
+    def cmd = "docker pull $validatorDockerImage &&" +
               'docker run --rm -v "$PWD:/sqa" ' + "$validatorDockerImage /sqa/${configFile}"
     return sh(returnStatus: true, script: cmd)
 }
 
-def checkoutRepository(String repository, String branch='master') {
+def checkoutRepository(String repository, String branch='master', String credentialsId) {
     if (repository) {
         checkout([
             $class: 'GitSCM',
             branches: [[name: "*/${branch}"]],
             extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: '.']],
-            userRemoteConfigs: [[url: repository]]])
+            userRemoteConfigs: [[url: repository, credentialsId: credentialsId]]])
     }
     else {
         checkout scm


### PR DESCRIPTION
Is possible to define for each config.project_repo the property credentials_id. This will allow to fetch from private repository.
Since GIT_ASKPASS environment variable is defined it should be also possible to push into repository (need to be tested).

For triggered repository credentials need to be passed as argument to pipelineConfig. This will override the default scm checkout behavior.

It is also possible to use the config.Credentials namespace to add any required credentials.

Closes #78 
Closes #48 
