### PR TITLE
Add docker-compose push support using predefined environment variables

### DIFF
--- a/src/eu/indigo/JenkinsDefinitions.groovy
+++ b/src/eu/indigo/JenkinsDefinitions.groovy
@@ -11,6 +11,9 @@ class JenkinsDefinitions implements Serializable {
     def steps
 
     protected final boolean _DEBUG_ = true
+    protected final boolean _WORKSPACEDEBUG_ = false
+    protected final int _WORKSPACEDEBUGTIMEOUT_ = 5
+    protected final String _WORKSPACEDEBUGUNIT_ = 'MINUTES'
     protected int logLevel = 0
     protected final int _LOGLEVELMAX_ = -1
 

--- a/src/eu/indigo/JenkinsDefinitions.groovy
+++ b/src/eu/indigo/JenkinsDefinitions.groovy
@@ -10,7 +10,7 @@ class JenkinsDefinitions implements Serializable {
 
     def steps
 
-    protected final boolean _DEBUG_ = true
+    protected final boolean _DEBUG_ = false
     protected final boolean _WORKSPACEDEBUG_ = false
     protected final int _WORKSPACEDEBUGTIMEOUT_ = 5
     protected final String _WORKSPACEDEBUGUNIT_ = 'MINUTES'

--- a/src/eu/indigo/Tox.groovy
+++ b/src/eu/indigo/Tox.groovy
@@ -30,7 +30,7 @@ class Tox extends JenkinsDefinitions implements Serializable {
      * @param testenv Test environment to run with tox
      */
     def runEnv(Map args, String testenv) {
-        return "tox -c \\\\\"${args.toxFile}\\\\\" -e $testenv"
+        return "tox -c \"${args.toxFile}\" -e $testenv"
     }
 
 }

--- a/src/eu/indigo/Tox.groovy
+++ b/src/eu/indigo/Tox.groovy
@@ -30,7 +30,7 @@ class Tox extends JenkinsDefinitions implements Serializable {
      * @param testenv Test environment to run with tox
      */
     def runEnv(Map args, String testenv) {
-        return "tox -c \"${args.toxFile}\" -e $testenv"
+        return "tox -c \\\\\"${args.toxFile}\\\\\" -e $testenv"
     }
 
 }

--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -21,6 +21,7 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
     String _f = '-f'
     String _w = '--project-directory'
     String _ipf = '--ignore-push-failures'
+    String _b = '--build'
 
 
     /**
@@ -178,13 +179,14 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
     * Run docker compose up
     *
     * @param serviceIds String with list of Service names separated by spaces to start [default]
+    * @param args.forceBuild If defined will force the build of all images in docker-compose.yml
     * @param args.composeFile Docker compose file to override the default docker-compose.yml [default]
     * @param args.workdir Path to workdir directory for this command
     * @see https://docs.docker.com/compose/reference/up/
     * @see https://docs.docker.com/compose/reference/overview/
     */
     def composeUp(Map args, String serviceIds='') {
-        String cmd = parseParam(_f, escapeWhitespace(args.composeFile)) + ' ' + parseParam(_w, escapeWhitespace(args.workdir)) + " up -d $serviceIds"
+        String cmd = parseParam(_f, escapeWhitespace(args.composeFile)) + ' ' + parseParam(_w, escapeWhitespace(args.workdir)) + " up " + testString(args.forceBuild) ? _b : '' + " -d $serviceIds"
 
         steps.sh "docker-compose $cmd"
     }
@@ -255,6 +257,9 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
     * @see https://docs.docker.com/compose/reference/exec/
     */
     def composeToxRun(Map args, String service, String testenv, Tox tox) {
+        if (_DEBUG_) { steps.echo "** composeToxRun() **" }
+        if (_DEBUG_) { steps.echo "service: ${service}\ntestenv: ${testenv}\ntoxFile: " + escapeWhitespace(args.toxFile) }
+
         String cmd = parseParam(_f, escapeWhitespace(args.composeFile)) + ' ' + parseParam(_w, escapeWhitespace(args.workdir)) + ' exec -T ' +
                      + getCredsVars() + " $service " + tox.runEnv(testenv, toxFile: escapeWhitespace(args.toxFile))
         steps.sh "docker-compose $cmd"
@@ -314,7 +319,7 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
             projectConfig.stagesList.each { stageMap ->
                 withCredentialsClosure(credentials) {
                     // Deploy the environment services using docker-compose
-                    composeUp(composeFile: projectConfig.config.deploy_template, workdir: workspace)
+                    composeUp(composeFile: projectConfig.config.deploy_template, workdir: workspace, forceBuild: steps.env.JPL_DOCKERFORCEBUILD)
                     
                     if (_DEBUG_) { steps.sh 'echo "after loading credentials:\n$(env)"' }
                     // Run the defined steps

--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -331,7 +331,9 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
 
                     // Push docker images to registry
                     if (steps.env.JPL_DOCKERPUSH) {
-                        composePush(composeFile: projectConfig.config.deploy_template, workdir: workspace, steps.env.JPL_DOCKERPUSH, steps.env.JPL_IGNOREFAILURES)
+                        steps.stage('Push Images to Docker Registry') {
+                            composePush(composeFile: projectConfig.config.deploy_template, workdir: workspace, steps.env.JPL_DOCKERPUSH, steps.env.JPL_IGNOREFAILURES)
+                        }
                     }
                 }
             }

--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -197,6 +197,9 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
     *
     * @param serviceIds String with list of Service names separated by spaces to start [default]
     * @param ignoreFailures Will ignore push failures if a string is defined.
+    * @param args.registryServer Define the server name and port to connect (example: localhost:8080)
+    * @param args.username Docker registry username
+    * @param args.password Docker registry password
     * @param args.composeFile Docker compose file to override the default docker-compose.yml [default]
     * @param args.workdir Path to workdir directory for this command
     * @see https://docs.docker.com/compose/reference/up/
@@ -206,7 +209,9 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
         String failuresFlag = testString(ignoreFailures) ? _ipf : ''
         String cmd = parseParam(_f, escapeWhitespace(args.composeFile)) + ' ' + parseParam(_w, escapeWhitespace(args.workdir)) + " push $failuresFlag $serviceCmd"
 
+        steps.sh "docker login -u \"${args.username}\" -p \"${args.password}\" ${args.registryServer}"
         steps.sh "docker-compose $cmd"
+        steps.sh "docker logout ${args.registryServer}"
     }
 
     /**
@@ -334,7 +339,7 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
                 // Push docker images to registry
                 if (steps.env.JPL_DOCKERPUSH) {
                     steps.stage('Push Images to Docker Registry') {
-                        composePush(composeFile: projectConfig.config.deploy_template, workdir: workspace, steps.env.JPL_DOCKERPUSH, steps.env.JPL_IGNOREFAILURES)
+                        composePush(composeFile: projectConfig.config.deploy_template, workdir: workspace, registryServer: steps.env.JPL_DOCKERSERVER, username: steps.env.JPL_DOCKERUSER, password: steps.env.JPL_DOCKERPASS, steps.env.JPL_DOCKERPUSH, steps.env.JPL_IGNOREFAILURES)
                     }
                 }
             }

--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -336,6 +336,13 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
                 }
             }
         } finally {
+            // Review execution before exit if debug mode enabled
+            if (_DEBUG_) {
+                steps.timeout(time: 15, unit: 'MINUTES') {
+                    steps.input message: 'Click finish after reviewing the current job (will automatically finish in 15min).', ok: 'finish'
+                }
+            }
+
             // Clean docker-compose deployed environment
             steps.stage('Docker Compose cleanup') {
                 composeDown(composeFile: projectConfig.config.deploy_template, workdir: workspace)

--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -265,7 +265,7 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
         if (_DEBUG_) { steps.echo "service: ${service}\ntestenv: ${testenv}\ntoxFile: " + escapeWhitespace(args.toxFile) + "\ncredsVars: $credsVars" }
         if (_DEBUG_) { steps.echo "tox command: " + tox.runEnv(testenv, toxFile: escapeWhitespace(args.toxFile)) }
         String cmd = parseParam(_f, escapeWhitespace(args.composeFile)) + ' ' + parseParam(_w, escapeWhitespace(args.workdir)) + ' exec -T ' +
-                     + " $credsVars $service " + tox.runEnv(testenv, toxFile: escapeWhitespace(args.toxFile))
+                     " $credsVars $service " + tox.runEnv(testenv, toxFile: escapeWhitespace(args.toxFile))
         steps.sh "docker-compose $cmd"
     }
 

--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -348,7 +348,7 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
             if (_WORKSPACEDEBUG_) {
                 try {
                     steps.timeout(time: _WORKSPACEDEBUGTIMEOUT_, unit: _WORKSPACEDEBUGUNIT_) {
-                        steps.input message: 'Click finish after reviewing the current job (will automatically finish in 15min).', ok: 'finish'
+                        steps.input message: "Click finish after reviewing the current job (will automatically finish in ${_WORKSPACEDEBUGTIMEOUT_} ${_WORKSPACEDEBUGUNIT_}).", ok: 'finish'
                     }
                 } catch(org.jenkinsci.plugins.workflow.steps.FlowInterruptedException ex) {
                     steps.echo "Cleaning workspace after timeout expired..."

--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -260,10 +260,11 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
     */
     def composeToxRun(Map args, String service, String testenv, Tox tox) {
         if (_DEBUG_) { steps.echo "** composeToxRun() **" }
-        if (_DEBUG_) { steps.echo "service: ${service}\ntestenv: ${testenv}\ntoxFile: " + escapeWhitespace(args.toxFile) }
 
+        String credsVars = getCredsVars()
+        if (_DEBUG_) { steps.echo "service: ${service}\ntestenv: ${testenv}\ntoxFile: " + escapeWhitespace(args.toxFile) + "\ncredsVars: $credsVars" }
         String cmd = parseParam(_f, escapeWhitespace(args.composeFile)) + ' ' + parseParam(_w, escapeWhitespace(args.workdir)) + ' exec -T ' +
-                     + getCredsVars() + " $service " + tox.runEnv(testenv, toxFile: escapeWhitespace(args.toxFile))
+                     + " $credsVars $service " + tox.runEnv(testenv, toxFile: escapeWhitespace(args.toxFile))
         steps.sh "docker-compose $cmd"
     }
 

--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -186,7 +186,8 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
     * @see https://docs.docker.com/compose/reference/overview/
     */
     def composeUp(Map args, String serviceIds='') {
-        String cmd = parseParam(_f, escapeWhitespace(args.composeFile)) + ' ' + parseParam(_w, escapeWhitespace(args.workdir)) + " up " + testString(args.forceBuild) ? _b : '' + " -d $serviceIds"
+        String buildFlag = testString(args.forceBuild) ? _b : ''
+        String cmd = parseParam(_f, escapeWhitespace(args.composeFile)) + ' ' + parseParam(_w, escapeWhitespace(args.workdir)) + " up $buildFlag -d $serviceIds"
 
         steps.sh "docker-compose $cmd"
     }
@@ -202,7 +203,8 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
     */
     def composePush(Map args, String serviceIds, String ignoreFailures='') {
         String serviceCmd = serviceIds.equalsIgnoreCase('all') ? '' : serviceIds
-        String cmd = parseParam(_f, escapeWhitespace(args.composeFile)) + ' ' + parseParam(_w, escapeWhitespace(args.workdir)) + " push " + testString(ignoreFailures) ? _ipf : '' + " $serviceCmd"
+        String failuresFlag = testString(ignoreFailures) ? _ipf : ''
+        String cmd = parseParam(_f, escapeWhitespace(args.composeFile)) + ' ' + parseParam(_w, escapeWhitespace(args.workdir)) + " push $failuresFlag $serviceCmd"
 
         steps.sh "docker-compose $cmd"
     }

--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -337,9 +337,9 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
             }
         } finally {
             // Review execution before exit if debug mode enabled
-            if (_DEBUG_) {
+            if (_WORKSPACEDEBUG_) {
                 try {
-                    steps.timeout(time: 15, unit: 'MINUTES') {
+                    steps.timeout(time: _WORKSPACEDEBUGTIMEOUT_, unit: _WORKSPACEDEBUGUNIT_) {
                         steps.input message: 'Click finish after reviewing the current job (will automatically finish in 15min).', ok: 'finish'
                     }
                 } catch(org.jenkinsci.plugins.workflow.steps.FlowInterruptedException ex) {

--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -319,12 +319,12 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
                     if (_DEBUG_) { steps.sh 'echo "after loading credentials:\n$(env)"' }
                     // Run the defined steps
                     runExecSteps(stageMap, projectConfig, workspace)
-                }
-            }
 
-            // Push docker images to registry
-            if (steps.env.JPL_DOCKERPUSH) {
-                composePush(composeFile: projectConfig.config.deploy_template, workdir: workspace, steps.env.JPL_DOCKERPUSH, steps.env.JPL_IGNOREFAILURES)
+                    // Push docker images to registry
+                    if (steps.env.JPL_DOCKERPUSH) {
+                        composePush(composeFile: projectConfig.config.deploy_template, workdir: workspace, steps.env.JPL_DOCKERPUSH, steps.env.JPL_IGNOREFAILURES)
+                    }
+                }
             }
         } finally {
             // Clean docker-compose deployed environment

--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -338,8 +338,12 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
         } finally {
             // Review execution before exit if debug mode enabled
             if (_DEBUG_) {
-                steps.timeout(time: 15, unit: 'MINUTES') {
-                    steps.input message: 'Click finish after reviewing the current job (will automatically finish in 15min).', ok: 'finish'
+                try {
+                    steps.timeout(time: 15, unit: 'MINUTES') {
+                        steps.input message: 'Click finish after reviewing the current job (will automatically finish in 15min).', ok: 'finish'
+                    }
+                } catch(org.jenkinsci.plugins.workflow.steps.FlowInterruptedException ex) {
+                    steps.echo "Cleaning workspace after timeout expired..."
                 }
             }
 

--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -263,6 +263,7 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
 
         String credsVars = getCredsVars()
         if (_DEBUG_) { steps.echo "service: ${service}\ntestenv: ${testenv}\ntoxFile: " + escapeWhitespace(args.toxFile) + "\ncredsVars: $credsVars" }
+        if (_DEBUG_) { steps.echo "tox command: " + tox.runEnv(testenv, toxFile: escapeWhitespace(args.toxFile)) }
         String cmd = parseParam(_f, escapeWhitespace(args.composeFile)) + ' ' + parseParam(_w, escapeWhitespace(args.workdir)) + ' exec -T ' +
                      + " $credsVars $service " + tox.runEnv(testenv, toxFile: escapeWhitespace(args.toxFile))
         steps.sh "docker-compose $cmd"

--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -193,13 +193,14 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
     * Run docker compose push
     *
     * @param serviceIds String with list of Service names separated by spaces to start [default]
-    * @param ignoreFailures Will ignore push failures if defined.
+    * @param ignoreFailures Will ignore push failures if a string is defined.
     * @param args.composeFile Docker compose file to override the default docker-compose.yml [default]
     * @param args.workdir Path to workdir directory for this command
     * @see https://docs.docker.com/compose/reference/up/
     */
-    def composePush(Map args, serviceIds='', ignoreFailures='') {
-        String cmd = parseParam(_f, escapeWhitespace(args.composeFile)) + ' ' + parseParam(_w, escapeWhitespace(args.workdir)) + " push " + testString(ignoreFailures) ? _ipf : '' + " $serviceIds"
+    def composePush(Map args, String serviceIds, String ignoreFailures='') {
+        String serviceCmd = serviceIds.equalsIgnoreCase('all') ? '' : serviceIds
+        String cmd = parseParam(_f, escapeWhitespace(args.composeFile)) + ' ' + parseParam(_w, escapeWhitespace(args.workdir)) + " push " + testString(ignoreFailures) ? _ipf : '' + " $serviceCmd"
 
         steps.sh "docker-compose $cmd"
     }


### PR DESCRIPTION
This is required for Worsica thematic service, so is possible to push the docker images into the defined registry.
Push will run if environment variable JPL_DOCKERPUSH is defined. It should have the list of services separated by spaces to push the referenced images. If the value is ALL it will push all local built images defined in docker-compose.yml.
There is also a special environment variable JPL_IGNOREFAILURES that if it is defined with some string without spaces, docker-compose push will ignore push failures.
To force the related images build define JPL_DOCKERFORCEBUILD with some string. This will forcedly rebuild all images with build clause in docker-compose.yml.
In case of using a docker registry server different from dockerhub, it can be set using the environment variable JPL_DOCKERSERVER.
Docker Registry credentials must be defined using the following environment variables:
- JPL_DOCKERUSER: username
- JPL_DOCKERPASS: password

Image definitions will be placed in docker-compose.yml. Relevant details to add to JPL documentation in the following page:
https://docs.docker.com/compose/compose-file/#image

Note: the official solution that will be provided through config.yml is buildpack with the reasons explained in the following issue
https://github.com/indigo-dc/jenkins-pipeline-library/issues/40
This is only an alternative approach for those who don't want to use buildpack.