### PR TITLE
GitHub workflow to automatically create a jenkins/release/<release-version> when pushing to release

### DIFF
--- a/.github/workflows/jenkins_branch.yml
+++ b/.github/workflows/jenkins_branch.yml
@@ -10,3 +10,7 @@ jobs:
               uses: actions/checkout@v2
               with:
                 fetch-depth: 0
+            - name: Get release version from branch name
+              run: |
+                  echo ::set-env name=BRANCH_NAME::$(git rev-parse --abbrev-ref HEAD | cut -d '/' -f2)
+

--- a/.github/workflows/jenkins_branch.yml
+++ b/.github/workflows/jenkins_branch.yml
@@ -1,39 +1,40 @@
 name: Handle jenkins branch for release validation
 on:
   push:
+    branches:
+      - 'release/**'
 jobs:
     create_jenkins_branch:
-        name: Creates jenkins/release/* branch if it does not exist
-        runs-on: ubuntu-latest
-        steps:
-            - name: Fetch full history
-              uses: actions/checkout@v2
-              with:
-                fetch-depth: 0
-            - name: Get release version from branch name
-              run: |
-                  echo ::set-env name=BRANCH_NAME::$(git rev-parse --abbrev-ref HEAD | cut -d '/' -f2)
-            - name: Find out if jenkins/release/${{ env.BRANCH_NAME }} exists
-              run: |
-                  echo ::set-env name=BRANCH_EXISTS::$(git branch -r | grep jenkins/release/${{ env.BRANCH_NAME }})
-            - name: Create jenkins/release/
-              uses: peterjgrainger/action-create-branch@v1.0.0
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  branch: jenkins/release/${{ env.BRANCH_NAME }}
-              if: "!env.BRANCH_EXISTS"
-            - name: Fetch new jenkins/release/${{ env.BRANCH_NAME }}
-              uses: actions/checkout@v2
-              with:
-                ref: jenkins/release/${{ env.BRANCH_NAME }}
-            - name: Update JePL branch content in jenkins/release/${{ env.BRANCH_NAME }}
-              run: |
-                  git config user.name github-actions
-                  git config user.email github-actions@github.com
-                  git checkout jenkins/release/${{ env.BRANCH_NAME }}
-                  git reset --hard origin/release/${{ env.BRANCH_NAME }}
-                  git checkout origin/JePL .sqa/config.yml .sqa/docker-compose.yml Jenkinsfile
-                  git status
-                  git diff-index --quiet HEAD || (git commit -m "Added JePL configuration files" && git push)
-
+      name: Creates jenkins/release/* branch if it does not exist
+      runs-on: ubuntu-latest
+      steps:
+        - name: Fetch full history
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+        - name: Get release version from branch name
+          run: |
+            echo ::set-env name=BRANCH_NAME::$(git rev-parse --abbrev-ref HEAD | cut -d '/' -f2)
+        - name: Find out if jenkins/release/${{ env.BRANCH_NAME }} exists
+          run: |
+            echo ::set-env name=BRANCH_EXISTS::$(git branch -r | grep jenkins/release/${{ env.BRANCH_NAME }})
+        - name: Create jenkins/release/
+          uses: peterjgrainger/action-create-branch@v1.0.0
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            branch: jenkins/release/${{ env.BRANCH_NAME }}
+          if: "!env.BRANCH_EXISTS"
+        - name: Fetch new jenkins/release/${{ env.BRANCH_NAME }}
+          uses: actions/checkout@v2
+          with:
+            ref: jenkins/release/${{ env.BRANCH_NAME }}
+        - name: Update JePL branch content in jenkins/release/${{ env.BRANCH_NAME }}
+          run: |
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+            git checkout jenkins/release/${{ env.BRANCH_NAME }}
+            git reset --hard origin/release/${{ env.BRANCH_NAME }}
+            git checkout origin/JePL .sqa/config.yml .sqa/docker-compose.yml Jenkinsfile
+            git status
+            git diff-index --quiet HEAD || (git commit -m "Added JePL configuration files" && git push)

--- a/.github/workflows/jenkins_branch.yml
+++ b/.github/workflows/jenkins_branch.yml
@@ -23,3 +23,7 @@ jobs:
               with:
                   branch: jenkins/release/${{ env.BRANCH_NAME }}
               if: "!env.BRANCH_EXISTS"
+            - name: Fetch new jenkins/release/${{ env.BRANCH_NAME }}
+              uses: actions/checkout@v2
+              with:
+                ref: jenkins/release/${{ env.BRANCH_NAME }}

--- a/.github/workflows/jenkins_branch.yml
+++ b/.github/workflows/jenkins_branch.yml
@@ -1,0 +1,12 @@
+name: Handle jenkins branch for release validation
+on:
+  push:
+jobs:
+    create_jenkins_branch:
+        name: Creates jenkins/release/* branch if it does not exist
+        runs-on: ubuntu-latest
+        steps:
+            - name: Fetch full history
+              uses: actions/checkout@v2
+              with:
+                fetch-depth: 0

--- a/.github/workflows/jenkins_branch.yml
+++ b/.github/workflows/jenkins_branch.yml
@@ -27,3 +27,13 @@ jobs:
               uses: actions/checkout@v2
               with:
                 ref: jenkins/release/${{ env.BRANCH_NAME }}
+            - name: Update JePL branch content in jenkins/release/${{ env.BRANCH_NAME }}
+              run: |
+                  git config user.name github-actions
+                  git config user.email github-actions@github.com
+                  git checkout jenkins/release/${{ env.BRANCH_NAME }}
+                  git reset --hard origin/release/${{ env.BRANCH_NAME }}
+                  git checkout origin/JePL .sqa/config.yml .sqa/docker-compose.yml Jenkinsfile
+                  git status
+                  git diff-index --quiet HEAD || (git commit -m "Added JePL configuration files" && git push)
+

--- a/.github/workflows/jenkins_branch.yml
+++ b/.github/workflows/jenkins_branch.yml
@@ -13,4 +13,13 @@ jobs:
             - name: Get release version from branch name
               run: |
                   echo ::set-env name=BRANCH_NAME::$(git rev-parse --abbrev-ref HEAD | cut -d '/' -f2)
-
+            - name: Find out if jenkins/release/${{ env.BRANCH_NAME }} exists
+              run: |
+                  echo ::set-env name=BRANCH_EXISTS::$(git branch -r | grep jenkins/release/${{ env.BRANCH_NAME }})
+            - name: Create jenkins/release/
+              uses: peterjgrainger/action-create-branch@v1.0.0
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  branch: jenkins/release/${{ env.BRANCH_NAME }}
+              if: "!env.BRANCH_EXISTS"


### PR DESCRIPTION
The GitHub workflow only affects to `release/**` branches:

1. When pushing to release branches, the workflow checks the existence of the associated `jenkins/release/<release-version>` branch, creating it if needed
2. The jenkins branch is then synced with the latest content of the release branch
3. The final step is to add latest JePL configuration from the `JePL` branch
4. On push event, Jenkins should automatically execute the pipeline based on the presence of the `Jenkinsfile`