### PR TITLE
Get default node agent

### DIFF
--- a/src/eu/indigo/compose/parser/ConfigParser.groovy
+++ b/src/eu/indigo/compose/parser/ConfigParser.groovy
@@ -123,7 +123,7 @@ class ConfigParser extends JenkinsDefinitions implements Serializable {
 
     def getNodeAgent(yaml) {
         if (_DEBUG_) { steps.echo "** getNodeAgent() **" }
-        configToClass[(yaml.config.node_agent == null) ? DEFAULT_AGENT : yaml.config.node_agent]
+        configToClass[(yaml.config?.node_agent == null) ? DEFAULT_AGENT : yaml.config.node_agent]
     }
 
     def getCredentialType(Map creds) {


### PR DESCRIPTION
With no config, then the JePL code complains:

java.lang.NullPointerException: Cannot get property 'node_agent' on null object

when evaluating:

configToClass[(yaml.config.node_agent == null) ? DEFAULT_AGENT : yaml.config.node_agent]

so the code is expecting yaml.config.

With this patch the mentioned bug is corrected and yaml.config is not required anymore.