### PR TITLE
Fix/readme documentation url

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ orchestration tool to fire up the required set of services. In this example, the
 _You can check a full working example [here](https://github.com/EOSC-synergy/DEEPaaS)_
 
 __In order to get started with the library, please check our
-[documentation](https://indigo-dc.github.io/jenkins-pipeline-library/release/2.1.0/).__
+[documentation](https://indigo-dc.github.io/jenkins-pipeline-library/stable/2.1.0/).__
 
 ### Building documentation locally
 


### PR DESCRIPTION
Change readme documentation url to stable/2.1.0