### PR TITLE
Keep going executing the pipeline if a defined step fails

### DIFF
--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -338,7 +338,7 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
                 projectConfig.stagesList.each { stageMap ->
                     if (steps.env.JPL_KEEPGOING) {
                         // Catch error and continue to other steps
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                        steps.catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                             // Run the defined steps
                             runExecSteps(stageMap, projectConfig, workspace)
                         }

--- a/src/eu/indigo/compose/DockerCompose.groovy
+++ b/src/eu/indigo/compose/DockerCompose.groovy
@@ -336,8 +336,16 @@ class DockerCompose extends JenkinsDefinitions implements Serializable {
                 if (_DEBUG_) { steps.sh 'echo "after loading credentials:\n$(env)"' }
 
                 projectConfig.stagesList.each { stageMap ->
-                    // Run the defined steps
-                    runExecSteps(stageMap, projectConfig, workspace)
+                    if (steps.env.JPL_KEEPGOING) {
+                        // Catch error and continue to other steps
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            // Run the defined steps
+                            runExecSteps(stageMap, projectConfig, workspace)
+                        }
+                    } else {
+                        // Run the defined steps
+                        runExecSteps(stageMap, projectConfig, workspace)
+                    }
                 }
 
                 // Push docker images to registry


### PR DESCRIPTION
resolve #162 
To keep going execution of the pipeline if a defined step fails, just need to add a control environment variable to the config.yml configuration. Is only required to have JPL_KEEPGOING variable defined with any string and the pipeline will run all stages.
This haven't been tested yet with real use cases.