### PR TITLE
Change to new github plugin to create tag

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -26,7 +26,7 @@ jobs:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               CUSTOM_TAG: ${{ ENV.RELEASE_MILESTONE }}
               RELEASE_BRANCHES: stable/${{ env.RELEASE_MILESTONE }}
-              VERBOSE: true
+              VERBOSE: false
             if: "env.RELEASE_MILESTONE"
           - name: Get diff between main and stable branch
             id: tag_changes

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -21,11 +21,10 @@ jobs:
             if: "env.RELEASE_MILESTONE"
           - name: Creates a tag from stable branch
             id: tag_version
-            uses: mathieudutour/github-tag-action@v5.5
+            uses:  anothrNick/github-tag-action@v1.36.0
             with:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               CUSTOM_TAG: ${{ ENV.RELEASE_MILESTONE }}
-              WITH_V: false
               RELEASE_BRANCHES: stable/${{ env.RELEASE_MILESTONE }}
               VERBOSE: true
             if: "env.RELEASE_MILESTONE"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,11 +19,6 @@ jobs:
               ref: stable/${{ env.RELEASE_MILESTONE }}
               fetch-depth: 0
             if: "env.RELEASE_MILESTONE"
-          - name: Checkout the stable branch
-            run: |
-              git checkout stable/${{ env.RELEASE_MILESTONE }}
-            shell: bash
-            if: "env.RELEASE_MILESTONE"
           - name: Creates a tag from stable branch
             id: tag_version
             uses: anothrNick/github-tag-action@1.36.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -22,7 +22,7 @@ jobs:
           - name: Creates a tag from stable branch
             id: tag_version
             uses: anothrNick/github-tag-action@1.36.0
-            with:
+            env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               CUSTOM_TAG: ${{ ENV.RELEASE_MILESTONE }}
               RELEASE_BRANCHES: stable/${{ env.RELEASE_MILESTONE }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,6 +19,11 @@ jobs:
               ref: stable/${{ env.RELEASE_MILESTONE }}
               fetch-depth: 0
             if: "env.RELEASE_MILESTONE"
+          - name: Checkout the stable branch
+            run: |
+              git checkout stable/${{ env.RELEASE_MILESTONE }}
+            shell: bash
+            if: "env.RELEASE_MILESTONE"
           - name: Creates a tag from stable branch
             id: tag_version
             uses: anothrNick/github-tag-action@1.36.0
@@ -29,12 +34,12 @@ jobs:
               VERBOSE: false
             if: "env.RELEASE_MILESTONE"
           - name: Get diff between main and stable branch
-            id: tag_changes
             run: |
               echo "__DIFF__<<EOF" >> $GITHUB_ENV
               echo $(git diff --name-only origin/master origin/stable/${{ ENV.RELEASE_MILESTONE }}) >> $GITHUB_ENV
               echo "EOF" >> $GITHUB_ENV
             shell: bash
+            if: "env.RELEASE_MILESTONE"
           - name: Create github release for tag
             uses: ncipollo/release-action@v1
             with:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -30,7 +30,7 @@ jobs:
             if: "env.RELEASE_MILESTONE"
           - name: Get diff between main and stable branch
             id: tag_changes
-            run: echo "::set-output name=diff::$(git diff origin/master origin/stable/${{ ENV.RELEASE_MILESTONE }})"
+            run: echo "::set-output name=diff::$(git diff --name-only origin/master origin/stable/${{ ENV.RELEASE_MILESTONE }})"
             shell: bash
           - name: Create github release for tag
             uses: ncipollo/release-action@v1
@@ -39,10 +39,10 @@ jobs:
               name: Release ${{ steps.tag_version.outputs.new_tag }}
               body: |
                 ${{ github.event.milestone.title }}:
-                ${{ github.event.milestone.message }}
+                ${{ github.event.milestone.description }}
 
                 Changes:
-                ${{ steps.tag_changes.diff }}
+                ${{ steps.tag_changes.outputs.diff }}
               token: ${{ secrets.GITHUB_TOKEN }}
             if: "env.RELEASE_MILESTONE"
           - name: Expose git commit data

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -28,12 +28,21 @@ jobs:
               RELEASE_BRANCHES: stable/${{ env.RELEASE_MILESTONE }}
               VERBOSE: true
             if: "env.RELEASE_MILESTONE"
+          - name: Get diff between main and stable branch
+            id: tag_changes
+            run: echo "::set-output name=diff::$(git diff origin/main origin/stable/${{ ENV.RELEASE_MILESTONE }})"
+            shell: bash
           - name: Create github release for tag
             uses: ncipollo/release-action@v1
             with:
               tag: ${{ steps.tag_version.outputs.new_tag }}
               name: Release ${{ steps.tag_version.outputs.new_tag }}
-              body: ${{ steps.tag_version.outputs.new_tag }}
+              body: |
+                ${{ github.event.milestone.title }}:
+                ${{ github.event.milestone.message }}
+
+                Changes:
+                ${{ steps.tag_changes.diff }}
               token: ${{ secrets.GITHUB_TOKEN }}
             if: "env.RELEASE_MILESTONE"
           - name: Expose git commit data

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -21,7 +21,7 @@ jobs:
             if: "env.RELEASE_MILESTONE"
           - name: Creates a tag from stable branch
             id: tag_version
-            uses:  anothrNick/github-tag-action@v1.36.0
+            uses: anothrNick/github-tag-action@v1.36.0
             with:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               CUSTOM_TAG: ${{ ENV.RELEASE_MILESTONE }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -30,7 +30,10 @@ jobs:
             if: "env.RELEASE_MILESTONE"
           - name: Get diff between main and stable branch
             id: tag_changes
-            run: echo "::set-output name=diff::$(git diff --name-only origin/master origin/stable/${{ ENV.RELEASE_MILESTONE }})"
+            run: |
+              echo "__DIFF__<<EOF" >> $GITHUB_ENV
+              echo $(git diff --name-only origin/master origin/stable/${{ ENV.RELEASE_MILESTONE }}) >> $GITHUB_ENV
+              echo "EOF" >> $GITHUB_ENV
             shell: bash
           - name: Create github release for tag
             uses: ncipollo/release-action@v1
@@ -42,7 +45,7 @@ jobs:
                 ${{ github.event.milestone.description }}
 
                 Changes:
-                ${{ steps.tag_changes.outputs.diff }}
+                ${{ env.__DIFF__ }}
               token: ${{ secrets.GITHUB_TOKEN }}
             if: "env.RELEASE_MILESTONE"
           - name: Expose git commit data

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -21,7 +21,7 @@ jobs:
             if: "env.RELEASE_MILESTONE"
           - name: Creates a tag from stable branch
             id: tag_version
-            uses: anothrNick/github-tag-action@v1.36.0
+            uses: anothrNick/github-tag-action@1.36.0
             with:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               CUSTOM_TAG: ${{ ENV.RELEASE_MILESTONE }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -30,7 +30,7 @@ jobs:
             if: "env.RELEASE_MILESTONE"
           - name: Get diff between main and stable branch
             id: tag_changes
-            run: echo "::set-output name=diff::$(git diff origin/main origin/stable/${{ ENV.RELEASE_MILESTONE }})"
+            run: echo "::set-output name=diff::$(git diff origin/master origin/stable/${{ ENV.RELEASE_MILESTONE }})"
             shell: bash
           - name: Create github release for tag
             uses: ncipollo/release-action@v1

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -33,7 +33,7 @@ jobs:
             with:
               tag: ${{ steps.tag_version.outputs.new_tag }}
               name: Release ${{ steps.tag_version.outputs.new_tag }}
-              body: ${{ steps.tag_version.outputs.changelog }}
+              body: ${{ steps.tag_version.outputs.new_tag }}
               token: ${{ secrets.GITHUB_TOKEN }}
             if: "env.RELEASE_MILESTONE"
           - name: Expose git commit data


### PR DESCRIPTION
Signed-off-by: Samuel Bernardo <samuelbernardo.mail@gmail.com>
Since test can only occur in the default branch to test the PR needs to temporary change the default branch to this one.
This PR fixes #169 

Besides solving previous issue, this PR also changes the title and description of the new release, using stable milestone title and description.
Also collects the changed files between tag and master at the time of the creation (before the merge into master). That change log is added to the release description.